### PR TITLE
add explicit success and failure factory methods to LazyTry

### DIFF
--- a/src/main/java/io/strati/functional/LazyTry.java
+++ b/src/main/java/io/strati/functional/LazyTry.java
@@ -44,6 +44,14 @@ public class LazyTry<T> {
     this.supplier = supplier;
   }
 
+  public static <T> LazyTry<T> success(final T t) {
+    return new LazyTry<>(() ->  new Success<>(t));
+  }
+
+  public static <T> LazyTry<T> failure(final Throwable t) {
+    return new LazyTry<>(() ->  new Failure<>(t));
+  }
+
   public static <T> LazyTry<T> ofTry(final TrySupplier<Try<T>> s) {
     return new LazyTry<>(s);
   }

--- a/src/test/java/io/strati/functional/LazyTryTest.java
+++ b/src/test/java/io/strati/functional/LazyTryTest.java
@@ -230,11 +230,9 @@ public class LazyTryTest {
 
   @Test
   public void testFilter() {
-    LazyTry<Integer> lazyTryInt = LazyTry.ofFailable(() -> 13);
+    LazyTry<Integer> lazyTryInt = LazyTry.success(13);
     LazyTry<String> lazyTryString = LazyTry.ofFailable(() -> "foo");
-    LazyTry<Integer> failingLazyTry = LazyTry.ofFailable(() -> {
-      throw new Exception();
-    });
+    LazyTry<Integer> failingLazyTry = LazyTry.failure( new Exception());
 
     assertTrue(lazyTryInt.filter(i -> true).run().isSuccess());
     assertEquals("foo", lazyTryString.filter(i -> true).run().get());


### PR DESCRIPTION
the current way of having LazyTry return explicit failure is to wrap a throw statement in ofFailable, causing unnecessary exception handling in such case (try/catch block of Try.ofFailable).