### PR TITLE
Allow to restrict number of concurrent threads in half-open state

### DIFF
--- a/src/main/java/io/strati/functional/exception/CircuitBreakerOpenException.java
+++ b/src/main/java/io/strati/functional/exception/CircuitBreakerOpenException.java
@@ -16,13 +16,27 @@
 
 package io.strati.functional.exception;
 
+import io.strati.functional.resilience.CircuitBreaker;
+
 /**
  * @author WalmartLabs
  * @author Georgi Khomeriki [gkhomeriki@walmartlabs.com]
  */
 
 public class CircuitBreakerOpenException extends RuntimeException {
-  public CircuitBreakerOpenException(final String msg, final Throwable cause) {
+  private final CircuitBreaker.State state;
+
+  public CircuitBreakerOpenException(final String msg, final Throwable cause, CircuitBreaker.State state) {
     super(msg, cause);
+    this.state = state;
+  }
+
+  /**
+   * @return The state of the circuit breaker when this exception was thrown,
+   * either {@link io.strati.functional.resilience.CircuitBreaker.State#OPEN} or
+   * {@link io.strati.functional.resilience.CircuitBreaker.State#HALF_OPEN}
+   */
+  public CircuitBreaker.State getState() {
+    return state;
   }
 }

--- a/src/main/java/io/strati/functional/resilience/CircuitBreakerBuilder.java
+++ b/src/main/java/io/strati/functional/resilience/CircuitBreakerBuilder.java
@@ -46,6 +46,7 @@ public class CircuitBreakerBuilder {
   private Consumer<CircuitBreaker> toClosedStateListener;
   private Consumer<CircuitBreaker> toHalfOpenStateListener;
   private Consumer<CircuitBreaker> toOpenStateListener;
+  private Integer concurrentCallsInHalfOpenState = null;
 
   /**
    * Instantiate a new {@code CircuitBreakerBuilder}.
@@ -88,6 +89,18 @@ public class CircuitBreakerBuilder {
    */
   public CircuitBreakerBuilder threshold(final int threshold) {
     this.threshold = threshold;
+    return this;
+  }
+
+  /**
+   * Set the number of concurrent calls of the protected code if the circuit breaker in half open mode.
+   *
+   * @param concurrentCallsInHalfOpenState the maximum number of concurrent calls when the
+   *                                       circuit breaker is in half open state.
+   * @return {@code CircuitBreakerBuilder}
+   */
+  public CircuitBreakerBuilder concurrentCallsInHalfOpenState(final int concurrentCallsInHalfOpenState) {
+    this.concurrentCallsInHalfOpenState = concurrentCallsInHalfOpenState;
     return this;
   }
 
@@ -218,7 +231,7 @@ public class CircuitBreakerBuilder {
     if (timeout < 1) {
       timeout = DEFAULT_TIMEOUT;
     }
-    return new CircuitBreaker(name, threshold, timeout,
+    return new CircuitBreaker(name, threshold, timeout, concurrentCallsInHalfOpenState,
         getOrCreateListener(toClosedStateListener),
         getOrCreateListener(toHalfOpenStateListener),
         getOrCreateListener(toOpenStateListener));

--- a/src/main/java/io/strati/functional/resilience/HalfOpenFilter.java
+++ b/src/main/java/io/strati/functional/resilience/HalfOpenFilter.java
@@ -1,0 +1,55 @@
+package io.strati.functional.resilience;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Ensures that only a certain number of Threads execute the protectedAction of a CircuitBreaker.
+ */
+class HalfOpenFilter {
+
+  private Set<Long> currentThreads = new HashSet<>();
+
+  private int maxConcurrentThreads;
+
+  HalfOpenFilter(final int maxConcurrentThreads) {
+    this.maxConcurrentThreads = maxConcurrentThreads;
+  }
+
+  /**
+   * @return {@code true} iff the current thread may execute the protected action when the CircuitBreaker is
+   * currently in half-open state.
+   */
+  boolean enter() {
+    final long currentThreadId = Thread.currentThread().getId();
+
+    if (currentThreads.contains(currentThreadId)) {
+      // A recursive call that has already passed the owning CircuitBreaker. Let it pass again.
+      return true;
+    }
+
+    if (currentThreads.size() < maxConcurrentThreads) {
+      currentThreads.add(currentThreadId);
+      return true;
+    } else {
+      return false;
+    }
+
+  }
+
+  /**
+   * This method must be called when a Thread has called {@link #enter()} and has executed the protectedAction.
+   */
+  void exit() {
+    final long currentThreadId = Thread.currentThread().getId();
+
+    currentThreads.remove(currentThreadId);
+  }
+
+  /**
+   * Resets this filter when the CircuitBreaker goes into the open state.
+   */
+  public void reset() {
+    currentThreads.clear();
+  }
+}


### PR DESCRIPTION
It might make sense to only allow a limited number of threads to execute a protected action in CircuitBreaker in half open state before closing it again.

Let's say that the protected action executes an external system that blocks.
When switching from open to closed again only 1 or 2 threads should be allowed to execute this concurrently. 
Otherwise all clients/threads again block and fail resulting again in tens or hundreds of blocked threads before timeouts etc apply.

This PR adds a new parameter to the CircuitBreaker that allows to limit this:
```java
    CircuitBreaker cb = CircuitBreakerBuilder.create()
        .threshold(1)
        .timeout(100)
        .concurrentCallsInHalfOpenState(2)
        .build();
```
In this example only 2 threads are allowed to execute the protected action when the circuit breaker is in half open state. If one of these executions succeeds, the CircuitBreaker will go into the closed state again.