### PR TITLE
Added ifSuccess to Try and ifPresent to Optional to handle value class hierarchy

### DIFF
--- a/src/main/java/io/strati/functional/Optional.java
+++ b/src/main/java/io/strati/functional/Optional.java
@@ -130,6 +130,24 @@ public abstract class Optional<T> {
    *                              null
    */
   public abstract Optional<T> ifPresent(final Consumer<? super T> consumer);
+  
+  /**
+   * If a value is present, invoke the specified consumer with the value,
+   * otherwise do nothing.
+   * <p>
+   * Note: the (backwards compatible) difference with {@code java.util.Optional}
+   * here is that {@code ifPresent} returns the current {@code Optional} instead
+   * of {@code void}, this is so that expressions don't have to be broken up
+   * in order to do side-effects (i.e. perform actions).
+   *
+   * @param consumer block to be executed if a value is present
+   * @param t        the type of the value for which we call the given {@code consumer}
+   * @return This instance of {@code Optional} will be returned, no mutations will
+   * take place.
+   * @throws NullPointerException if value is present and {@code consumer} is
+   *                              null
+   */
+  public abstract Optional<T> ifPresent(Class<? extends T> t, Consumer<? super T> consumer);
 
   /**
    * If no value is present, invoke the specified runnable, otherwise do nothing.
@@ -313,6 +331,14 @@ final class Present<T> extends Optional<T> {
     consumer.accept(value);
     return this;
   }
+  
+  @Override
+  public Optional<T> ifPresent(Class<? extends T> t, final Consumer<? super T> consumer) {
+    if(t.isInstance(value)){
+      consumer.accept(value);
+    }
+    return this;
+  }
 
   @Override
   public Optional<T> ifEmpty(final Runnable runnable) {
@@ -395,6 +421,11 @@ final class Empty<T> extends Optional<T> {
 
   @Override
   public Optional<T> ifPresent(final Consumer<? super T> consumer) {
+    return this;
+  }
+  
+  @Override
+  public Optional<T> ifPresent(Class<? extends T> t, final Consumer<? super T> consumer) {
     return this;
   }
 

--- a/src/main/java/io/strati/functional/Try.java
+++ b/src/main/java/io/strati/functional/Try.java
@@ -197,6 +197,16 @@ public abstract class Try<T> {
   public abstract Try<T> ifSuccess(final TryConsumer<? super T> consumer);
 
   /**
+   * Applies the given {@code consumer} function if this is a {@code Success} and the value is an instance
+   * of the given class {@code t}
+   *
+   * @param consumer the function to apply
+   * @param t        the type of the value for which we call the given {@code consumer}
+   * @return the original {@code Try<T>}
+   */
+  public abstract Try<T> ifSuccess(final Class<? extends T> t, final TryConsumer<? super T> consumer);
+
+  /**
    * Executes the given {@code Runnable} if this is a {@code Success} and returns this, otherwise directly returns this.
    *
    * @param runnable the runnable action that performs side-effects
@@ -407,6 +417,18 @@ final class Success<T> extends Try<T> {
       return failure(e);
     }
   }
+  
+  @Override
+  public Try<T> ifSuccess(Class<? extends T> t, TryConsumer<? super T> consumer) {
+    try {
+      if(t.isInstance(value)){
+        consumer.accept(value);
+      }
+      return this;
+    } catch (final Exception e) {
+      return failure(e);
+    }
+  }
 
   @Override
   public Try<T> ifSuccess(final TryRunnable runnable) {
@@ -569,6 +591,11 @@ final class Failure<T> extends Try<T> {
 
   @Override
   public Try<T> ifSuccess(TryRunnable runnable) {
+    return this;
+  }
+  
+  @Override
+  public Try<T> ifSuccess(Class<? extends T> t, TryConsumer<? super T> consumer) {
     return this;
   }
 

--- a/src/test/java/io/strati/functional/OptionalTest.java
+++ b/src/test/java/io/strati/functional/OptionalTest.java
@@ -74,6 +74,20 @@ public class OptionalTest {
     assertTrue(test.get());
 
     ofNullable("foo").ifPresent(s -> assertEquals("foo", s));
+    
+    // Testing try for handling success for value class hierarchy
+    Optional<TestObjectSuper> tryOfParent = Optional.of(new TestObjectSibling());
+    
+    tryOfParent.ifPresent(TestObject.class, e -> {
+      throw new AssertionError("Wrong ifSuccess branch entered!");
+    });
+    
+    test.set(false);
+    tryOfParent.ifPresent(TestObjectSibling.class, e -> {
+      test.set(true);
+      assertTrue(TestObjectSibling.class.isInstance(e));
+    });
+    assertTrue(test.get());
   }
 
   @Test
@@ -227,6 +241,9 @@ public class OptionalTest {
   private class TestObject extends TestObjectSuper {
   }
 
+  private class TestObjectSibling extends TestObjectSuper {
+  }
+  
   private class TestObjectSub extends TestObject {
   }
 }

--- a/src/test/java/io/strati/functional/TryTest.java
+++ b/src/test/java/io/strati/functional/TryTest.java
@@ -83,6 +83,21 @@ public class TryTest {
     assertTrue(success(13).ifSuccess(() -> {
       throw new Exception();
     }).isFailure());
+    
+    
+    // Testing try for handling success for value class hierarchy
+    Try<TestObjectSuper> tryOfParent = success(new TestObjectSibling());
+    
+    tryOfParent.ifSuccess(TestObject.class, e -> {
+      throw new AssertionError("Wrong ifSuccess branch entered!");
+    });
+    
+    test.set(false);
+    tryOfParent.ifSuccess(TestObjectSibling.class, e -> {
+      test.set(true);
+      assertTrue(TestObjectSibling.class.isInstance(e));
+    });
+    assertTrue(test.get());
   }
 
   @Test
@@ -484,6 +499,9 @@ public class TryTest {
   private class TestObject extends TestObjectSuper {
   }
 
+  private class TestObjectSibling extends TestObjectSuper {
+  }
+  
   private class TestObjectSub extends TestObject {
   }
 


### PR DESCRIPTION
For example consider,

`Try<Vehicle> getVehicleDetails(id);`

`Car extends Vehicle`
`Bike extends Vehicle`

with newly added method we can handle class hierarchy like following:
```
getVehicleDetails(id)
       .ifSuccess(Car.class, e -> sendToCarMechanic(e))
       .ifSuccess(Bike.class, e -> sendToBikeMechanic(e));
```

In case we use `Optional`

`Try<Vehicle> getVehicleDetails(id);`

with newly added method we can handle class hierarchy like following:
```
getVehicleDetails(id)
       .ifPresent(Car.class, e -> sendToCarMechanic(e))
       .ifPresent(Bike.class, e -> sendToBikeMechanic(e));
```
